### PR TITLE
Implemented dependency graph for state management

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"stylelint-config-recommended-scss": "^14.1.0",
 		"stylelint-order": "^6.0.3",
 		"stylelint-scss": "^6.10.0",
-		"typescript": "^5.1.3",
+		"typescript": "^5.7.3",
 		"typescript-eslint": "^8.19.0"
 	},
 	"overrides": {

--- a/src/scripts/conversions.ts
+++ b/src/scripts/conversions.ts
@@ -1,4 +1,4 @@
-import { State } from "./state.js";
+import { State } from "./state/index.js";
 
 const earthRadius = 6371000;
 const earthCircumference = 2 * Math.PI * earthRadius;

--- a/src/scripts/map/canvas.ts
+++ b/src/scripts/map/canvas.ts
@@ -2,7 +2,7 @@ import { laneLength, metresToPixels } from "../conversions.js";
 import { DrawnElement, drawArrow, drawLine, drawPolygon, getSurfaceColour } from "../drawing.js";
 import { WAY_INFO, displayPopup } from "../popup/index.js";
 import { Settings } from "../settings.js";
-import { State } from "../state.js";
+import { State } from "../state/index.js";
 import { getElement } from "../supplement/elements.js";
 import { zoomIncrement } from "../supplement/index.js";
 import { ScreenCoordinate, WorldCoordinate } from "../types/coordinate.js";

--- a/src/scripts/overpass.ts
+++ b/src/scripts/overpass.ts
@@ -2,7 +2,7 @@ import { Database } from "./database.js";
 import { CANVAS } from "./map/canvas.js";
 import { MESSAGE_BOX, MessageBoxError } from "./messages.js";
 import { Settings } from "./settings.js";
-import { State } from "./state.js";
+import { State } from "./state/index.js";
 import { nullish } from "./supplement/index.js";
 import {
 	ImportedData,

--- a/src/scripts/popup/index.ts
+++ b/src/scripts/popup/index.ts
@@ -1,5 +1,5 @@
 import { ElementBuilder, FontAwesomeIcon } from "../elements.js";
-import { State } from "../state.js";
+import { State } from "../state/index.js";
 import { getElement } from "../supplement/elements.js";
 import { OverpassWay } from "../types/overpass.js";
 

--- a/src/scripts/popup/share.ts
+++ b/src/scripts/popup/share.ts
@@ -1,5 +1,5 @@
 import { ElementBuilder, FontAwesomeIcon } from "../elements.js";
-import { State } from "../state.js";
+import { State } from "../state/index.js";
 import { Popup, openID, openJOSM } from "./index.js";
 
 export class SharePopup extends Popup {

--- a/src/scripts/state/graph.ts
+++ b/src/scripts/state/graph.ts
@@ -1,0 +1,111 @@
+import { Compute, Effect, Store } from "./index.js";
+
+/**
+ * All {@link Compute} objects that have a registered dependency.
+ */
+const allComputes = new Set<Compute>();
+
+/**
+ * The dependency graph that maps each dependency as ({@link Compute}, {@link Store}).
+ *
+ * This graph is the backbone for trimming unnecessary dependencies. See
+ * {@link trimDependencies} for more information.
+ */
+const graph = new Set<[Compute, Store<unknown>]>();
+
+/**
+ * Register a dependency to the graph.
+ *
+ * @param dependent The dependent {@link Compute} value.
+ * @param dependency The {@link Store} the {@link dependent} depends on.
+ */
+export function registerDependency(dependent: Compute, dependency: Store<unknown>) {
+	allComputes.add(dependent);
+	graph.add([dependent, dependency]);
+	trimDependencies();
+}
+
+/**
+ * Deregister a dependency from the graph.
+ *
+ * @param dependent The dependent {@link Compute} value
+ * @param dependency The {@link Store} the {@link dependent} no longer should depend on.
+ * @returns Whether the dependency entry actually existed before removal.
+ */
+export function deregisterDependency(dependent: Compute, dependency: Store<unknown>) {
+	for (const item of graph)
+		if (item[0] === dependent && item[1] === dependency) return graph.delete(item);
+
+	return false;
+}
+
+/**
+ * Trim all the dependency relationships in the graph.
+ */
+function trimDependencies() {
+	for (const compute of allComputes) {
+		const { direct, indirect } = getAllDependencies(compute, compute, new Set(), new Set());
+
+		// remove unnecessary direct dependencies
+		for (const dependency of direct) {
+			if (!indirect.has(dependency)) continue;
+			dependency.trimDependent(compute);
+
+			// log removal
+			const dependencyName = dependency.name;
+			let computeName = "<unknown>";
+			if (compute instanceof Store) computeName = compute.name;
+			if (compute instanceof Effect) computeName = compute.name;
+
+			console.debug(
+				`Removed dependency '${dependencyName}' from '${computeName}' due to nested duplication.`
+			);
+		}
+	}
+}
+
+/**
+ * Find all dependencies for a {@link Compute}.
+ *
+ * Dependencies can either be direct (in cases where the {@link Compute} directly specifies a
+ * dependency) or indirect (in cases for dependencies of dependencies).
+ *
+ * @param compute The current {@link Compute} value to find all dependencies for.
+ * @param rootCompute The root {@link Compute} value which was originally requested.
+ * @param direct All currently discovered direct dependencies.
+ * @param indirect All currently discovered indirect dependencies.
+ * @returns All direct and indirect dependences of {@link rootCompute}.
+ */
+function getAllDependencies(
+	compute: Compute,
+	rootCompute: Compute,
+	direct: Set<Store<unknown>>,
+	indirect: Set<Store<unknown>>
+) {
+	for (const [dependent, dependency] of graph) {
+		// find all relevant dependencies
+		if (dependent !== compute) continue;
+
+		if (compute === rootCompute) direct.add(dependency);
+		else {
+			if (indirect.has(dependency)) continue;
+			indirect.add(dependency);
+		}
+
+		// check for any nested dependencies
+		if (isRegisteredCompute(dependency))
+			getAllDependencies(dependency, rootCompute, direct, indirect);
+	}
+
+	return { direct, indirect };
+}
+
+/**
+ * Determine whether a {@link Store} has been registered as a {@link Compute}.
+ *
+ * @param store The store to check.
+ * @returns Whether {@link store} is a registered {@link Compute}.
+ */
+function isRegisteredCompute(store: Store<unknown>): store is Store<unknown> & Compute {
+	return allComputes.has(store as unknown as Compute);
+}

--- a/src/scripts/state/index.ts
+++ b/src/scripts/state/index.ts
@@ -53,13 +53,6 @@ export class Store<T> extends GraphItem {
 	get() {
 		return this.data;
 	}
-
-	/**
-	 * Notify all dependent {@link Compute} containers that changes have been made to this value.
-	 */
-	protected notifyDependents() {
-		GraphItem.recalculateComputes(this);
-	}
 }
 
 /**
@@ -137,7 +130,7 @@ export class Computed<T> extends Store<T> implements Compute {
 		super(computeFn());
 		this.computeFn = computeFn;
 
-		for (const dependency of dependencies) GraphItem.registerDependency(this, dependency);
+		for (const dependency of dependencies) this.registerDependency(dependency);
 	}
 
 	compute() {
@@ -168,7 +161,7 @@ export class Effect extends GraphItem implements Compute {
 		super();
 		this.effectFn = effectFn;
 
-		for (const dependency of dependencies) GraphItem.registerDependency(this, dependency);
+		for (const dependency of dependencies) this.registerDependency(dependency);
 	}
 
 	compute() {

--- a/src/scripts/state/node.ts
+++ b/src/scripts/state/node.ts
@@ -1,0 +1,83 @@
+/**
+ * A node set is similar to a {@link Map}, except instead of all keys having to be unique, all
+ * key-value pairs have to be unique.
+ *
+ * Note this class has very poor performance and should generally only be used where performance is
+ * not paramount.
+ */
+export class GraphNodeSet<N1, N2> {
+	private readonly inner = new Set<[N1, N2]>();
+
+	/**
+	 * Add an item to the node set.
+	 *
+	 * @param first The item to add in the first place position on the set.
+	 * @param second The item to add in the second place position on the set.
+	 */
+	add(first: N1, second: N2) {
+		// ensure no duplicates
+		const newNode: [N1, N2] = [first, second];
+		for (const existingNode of this.inner)
+			if (this.areNodesEqual(newNode, existingNode)) return;
+
+		this.inner.add(newNode);
+	}
+
+	/**
+	 * Clear the node set.
+	 */
+	clear() {
+		this.inner.clear();
+	}
+
+	/**
+	 * Retrieve all {@link N2} values which have a relationship with a certain {@link N1} value.
+	 *
+	 * @param value The {@link N1} value to check a relationship with.
+	 * @returns All {@link N2} values with a relationship.
+	 */
+	getSecondsForFirst(value: N1): Set<N2> {
+		const set = new Set<N2>();
+
+		for (const [first, second] of this.inner) {
+			if (first === value) set.add(second);
+		}
+
+		return set;
+	}
+
+	/**
+	 * Retrieve all {@link N1} values which have a relationship with a certain {@link N2} value.
+	 *
+	 * @param value The {@link N2} value to check a relationship with.
+	 * @returns All {@link N1} values with a relationship.
+	 */
+	getFirstsForSecond(value: N2): Set<N1> {
+		const set = new Set<N1>();
+
+		for (const [first, second] of this.inner) {
+			if (second === value) set.add(first);
+		}
+
+		return set;
+	}
+
+	/**
+	 * Determine whether two nodes are equal.
+	 *
+	 * Since JavaScript compares values by reference comparison, an array containing the same two
+	 * objects in the same order will not register as being equal. Thus, this method performs a
+	 * deep comparison to determine whether the two nodes are equal.
+	 *
+	 * @param first The first node.
+	 * @param second The second node.
+	 * @returns Whether {@link first} and {@link second} represent the same node.
+	 */
+	private areNodesEqual(first: [N1, N2], second: [N1, N2]): boolean {
+		return first[0] === second[0] && first[1] === second[1];
+	}
+
+	[Symbol.iterator]() {
+		return this.inner[Symbol.iterator]();
+	}
+}

--- a/src/scripts/state/node.ts
+++ b/src/scripts/state/node.ts
@@ -31,22 +31,6 @@ export class GraphNodeSet<N1, N2> {
 	}
 
 	/**
-	 * Retrieve all {@link N2} values which have a relationship with a certain {@link N1} value.
-	 *
-	 * @param value The {@link N1} value to check a relationship with.
-	 * @returns All {@link N2} values with a relationship.
-	 */
-	getSecondsForFirst(value: N1): Set<N2> {
-		const set = new Set<N2>();
-
-		for (const [first, second] of this.inner) {
-			if (first === value) set.add(second);
-		}
-
-		return set;
-	}
-
-	/**
 	 * Retrieve all {@link N1} values which have a relationship with a certain {@link N2} value.
 	 *
 	 * @param value The {@link N2} value to check a relationship with.

--- a/src/scripts/types/coordinate.ts
+++ b/src/scripts/types/coordinate.ts
@@ -1,4 +1,4 @@
-import { State } from "../state.js";
+import { State } from "../state/index.js";
 import { OverpassNode } from "./overpass.js";
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		/* Target */
-		"target": "ES2022",
+		"target": "ESNext",
 		"module": "NodeNext",
 		"moduleResolution": "NodeNext",
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -361,21 +361,6 @@
     natural-compare "^1.4.0"
     ts-api-utils "^1.3.0"
 
-"@typescript-eslint/eslint-plugin@^8.18.2":
-  version "8.18.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.18.2.tgz#c78e363ab5fe3b21dd1c90d8be9581534417f78e"
-  integrity sha512-adig4SzPLjeQ0Tm+jvsozSGiCliI2ajeURDGHjZ2llnA+A67HihCQ+a3amtPhUakd1GlwHxSRvzOZktbEvhPPg==
-  dependencies:
-    "@eslint-community/regexpp" "^4.10.0"
-    "@typescript-eslint/scope-manager" "8.18.2"
-    "@typescript-eslint/type-utils" "8.18.2"
-    "@typescript-eslint/utils" "8.18.2"
-    "@typescript-eslint/visitor-keys" "8.18.2"
-    graphemer "^1.4.0"
-    ignore "^5.3.1"
-    natural-compare "^1.4.0"
-    ts-api-utils "^1.3.0"
-
 "@typescript-eslint/parser@8.19.0":
   version "8.19.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.19.0.tgz#f1512e6e5c491b03aabb2718b95becde22b15292"
@@ -387,25 +372,6 @@
     "@typescript-eslint/visitor-keys" "8.19.0"
     debug "^4.3.4"
 
-"@typescript-eslint/parser@^8.18.2":
-  version "8.18.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.18.2.tgz#0379a2e881d51d8fcf7ebdfa0dd18eee79182ce2"
-  integrity sha512-y7tcq4StgxQD4mDr9+Jb26dZ+HTZ/SkfqpXSiqeUXZHxOUyjWDKsmwKhJ0/tApR08DgOhrFAoAhyB80/p3ViuA==
-  dependencies:
-    "@typescript-eslint/scope-manager" "8.18.2"
-    "@typescript-eslint/types" "8.18.2"
-    "@typescript-eslint/typescript-estree" "8.18.2"
-    "@typescript-eslint/visitor-keys" "8.18.2"
-    debug "^4.3.4"
-
-"@typescript-eslint/scope-manager@8.18.2":
-  version "8.18.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.18.2.tgz#d193c200d61eb0ddec5987c8e48c9d4e1c0510bd"
-  integrity sha512-YJFSfbd0CJjy14r/EvWapYgV4R5CHzptssoag2M7y3Ra7XNta6GPAJPPP5KGB9j14viYXyrzRO5GkX7CRfo8/g==
-  dependencies:
-    "@typescript-eslint/types" "8.18.2"
-    "@typescript-eslint/visitor-keys" "8.18.2"
-
 "@typescript-eslint/scope-manager@8.19.0":
   version "8.19.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.19.0.tgz#28fa413a334f70e8b506a968531e0a7c9c3076dc"
@@ -413,16 +379,6 @@
   dependencies:
     "@typescript-eslint/types" "8.19.0"
     "@typescript-eslint/visitor-keys" "8.19.0"
-
-"@typescript-eslint/type-utils@8.18.2":
-  version "8.18.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-8.18.2.tgz#5ad07e09002eee237591881df674c1c0c91ca52f"
-  integrity sha512-AB/Wr1Lz31bzHfGm/jgbFR0VB0SML/hd2P1yxzKDM48YmP7vbyJNHRExUE/wZsQj2wUCvbWH8poNHFuxLqCTnA==
-  dependencies:
-    "@typescript-eslint/typescript-estree" "8.18.2"
-    "@typescript-eslint/utils" "8.18.2"
-    debug "^4.3.4"
-    ts-api-utils "^1.3.0"
 
 "@typescript-eslint/type-utils@8.19.0":
   version "8.19.0"
@@ -434,29 +390,10 @@
     debug "^4.3.4"
     ts-api-utils "^1.3.0"
 
-"@typescript-eslint/types@8.18.2":
-  version "8.18.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.18.2.tgz#5ebad5b384c8aa1c0f86cee1c61bcdbe7511f547"
-  integrity sha512-Z/zblEPp8cIvmEn6+tPDIHUbRu/0z5lqZ+NvolL5SvXWT5rQy7+Nch83M0++XzO0XrWRFWECgOAyE8bsJTl1GQ==
-
 "@typescript-eslint/types@8.19.0":
   version "8.19.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.19.0.tgz#a190a25c5484a42b81eaad06989579fdeb478cbb"
   integrity sha512-8XQ4Ss7G9WX8oaYvD4OOLCjIQYgRQxO+qCiR2V2s2GxI9AUpo7riNwo6jDhKtTcaJjT8PY54j2Yb33kWtSJsmA==
-
-"@typescript-eslint/typescript-estree@8.18.2":
-  version "8.18.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.18.2.tgz#fffb85527f8304e29bfbbdc712f4515da9f8b47c"
-  integrity sha512-WXAVt595HjpmlfH4crSdM/1bcsqh+1weFRWIa9XMTx/XHZ9TCKMcr725tLYqWOgzKdeDrqVHxFotrvWcEsk2Tg==
-  dependencies:
-    "@typescript-eslint/types" "8.18.2"
-    "@typescript-eslint/visitor-keys" "8.18.2"
-    debug "^4.3.4"
-    fast-glob "^3.3.2"
-    is-glob "^4.0.3"
-    minimatch "^9.0.4"
-    semver "^7.6.0"
-    ts-api-utils "^1.3.0"
 
 "@typescript-eslint/typescript-estree@8.19.0":
   version "8.19.0"
@@ -472,16 +409,6 @@
     semver "^7.6.0"
     ts-api-utils "^1.3.0"
 
-"@typescript-eslint/utils@8.18.2":
-  version "8.18.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.18.2.tgz#a2635f71904a84f9e47fe1b6f65a6d944ff1adf9"
-  integrity sha512-Cr4A0H7DtVIPkauj4sTSXVl+VBWewE9/o40KcF3TV9aqDEOWoXF3/+oRXNby3DYzZeCATvbdksYsGZzplwnK/Q==
-  dependencies:
-    "@eslint-community/eslint-utils" "^4.4.0"
-    "@typescript-eslint/scope-manager" "8.18.2"
-    "@typescript-eslint/types" "8.18.2"
-    "@typescript-eslint/typescript-estree" "8.18.2"
-
 "@typescript-eslint/utils@8.19.0":
   version "8.19.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.19.0.tgz#33824310e1fccc17f27fbd1030fd8bbd9a674684"
@@ -491,14 +418,6 @@
     "@typescript-eslint/scope-manager" "8.19.0"
     "@typescript-eslint/types" "8.19.0"
     "@typescript-eslint/typescript-estree" "8.19.0"
-
-"@typescript-eslint/visitor-keys@8.18.2":
-  version "8.18.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.18.2.tgz#b3e434b701f086b10a7c82416ebc56899d27ef2f"
-  integrity sha512-zORcwn4C3trOWiCqFQP1x6G3xTRyZ1LYydnj51cRnJ6hxBlr/cKPckk+PKPUw/fXmvfKTcw7bwY3w9izgx5jZw==
-  dependencies:
-    "@typescript-eslint/types" "8.18.2"
-    eslint-visitor-keys "^4.2.0"
 
 "@typescript-eslint/visitor-keys@8.19.0":
   version "8.19.0"
@@ -1996,10 +1915,10 @@ typescript-eslint@^8.19.0:
     "@typescript-eslint/parser" "8.19.0"
     "@typescript-eslint/utils" "8.19.0"
 
-typescript@^5.1.3:
-  version "5.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.2.tgz#3169cf8c4c8a828cde53ba9ecb3d2b1d5dd67be6"
-  integrity sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==
+typescript@^5.7.3:
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.3.tgz#919b44a7dbb8583a9b856d162be24a54bf80073e"
+  integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==
 
 update-check@1.5.4:
   version "1.5.4"


### PR DESCRIPTION
## Overview

State management relies on two main concepts: stores and computes where stores can contain data and computes can perform calculations. However, the computes require specifying what stores they depend on which could arises cases of unnecessary recalculations if both a store and one of it's dependencies both depend on the same other store. To resolve this, a dependency graph has been implemented to automatically trim and manage these dependencies to limit the number of unnecessary recalculations performed.

## Notes

* This implemented is fairly rudimentary, performing graph pruning by removing direct dependency relationships where an indirect on already exists. Thus, further optimisations could still be made, for example if two dependencies share a dependency, the current implementation will recalculate twice instead of waiting for both dependencies to recalculate before recalculating itself. This would require deeper analysis of the dependency graph to achieve.
* It is also possible now to detect when a circular dependency exists, however this also is currently not implemented, leading to the potentially for the application to hang indefinitely if two stores become dependent on each other, directly or indirectly, with no error being thrown.
* This implementation requires the use of JavaScript's new `Set` method [`Set.prototype.difference()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/difference), so to be safe, the TypeScript version has been bumped to latest and the target to `ESNext` as appears to be the only target which contains this method. In the future, this should be moved off `ESNext` into a set standard, such as `ES2024` with `lib` to allow TypeScript to compile the function. This also does mean the minimum browser requirement to run the application is only sitting around 88% market at the time of writing.