### PR TITLE
Moved to automatic dependency discovery for state management

### DIFF
--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -2,6 +2,7 @@ import { loadSearchBox } from "./map/search.js";
 import { displayMessage } from "./messages.js";
 import { WELCOME_POPUP } from "./popup/welcome.js";
 import { Settings } from "./settings.js";
+import { Effect, State } from "./state/index.js";
 
 // display a message on the message popup when a JS error occurs
 window.addEventListener("error", () => displayMessage("error"));
@@ -10,6 +11,7 @@ window.addEventListener("error", () => displayMessage("error"));
 const hash = window.location.hash;
 const id = Number(hash.substring(1));
 if (hash.length > 0 && !isNaN(id)) await loadSearchBox(id.toString());
+new Effect(() => (window.location.hash = `#${State.currentRelationId.get()}`));
 
 // first time popup
 if (Settings.get("firstLaunch")) {

--- a/src/scripts/map/canvas.ts
+++ b/src/scripts/map/canvas.ts
@@ -2,7 +2,7 @@ import { laneLength, metresToPixels } from "../conversions.js";
 import { DrawnElement, drawArrow, drawLine, drawPolygon, getSurfaceColour } from "../drawing.js";
 import { WAY_INFO, displaySidebar } from "../popup/index.js";
 import { Settings } from "../settings.js";
-import { State } from "../state/index.js";
+import { Effect, State } from "../state/index.js";
 import { getElement } from "../supplement/elements.js";
 import { zoomIncrement } from "../supplement/index.js";
 import { ScreenCoordinate, WorldCoordinate } from "../types/coordinate.js";
@@ -422,4 +422,8 @@ class Canvas {
 	}
 }
 
+// canvas instance
 export const CANVAS = new Canvas("canvas", "canvas-container", "main");
+
+// canvas effects
+new Effect(() => CANVAS.draw());

--- a/src/scripts/state/graph.ts
+++ b/src/scripts/state/graph.ts
@@ -1,5 +1,5 @@
+import { MessageBoxError } from "../messages.js";
 import { Compute, Store } from "./index.js";
-import { GraphNodeSet } from "./node.js";
 
 /**
  * The type that this graph recognises as a dependency.
@@ -19,121 +19,140 @@ type Dependency = Store<unknown>;
  */
 export abstract class GraphItem {
 	/**
-	 * All {@link Compute} values which have been registered under the
-	 * {@link GraphItem.dependencyGraph}.
+	 * Map to keep track of which {@link Dependency Dependencies} each {@link Compute} relies on.
 	 */
-	private static readonly allComputes = new Set<Compute>();
+	static readonly dependencyMap = new Map<Compute, Set<Dependency>>();
 
 	/**
-	 * The original dependency graph which maintains a record for the desired dependency
-	 * relationships for all {@link Compute} values.
-	 */
-	private static readonly dependencyGraph = new GraphNodeSet<Compute, Dependency>();
-
-	/**
-	 * The trimmed dependency graph which aims to optimise the {@link GraphItem.dependencyGraph} to
-	 * reduce the number of times an unnecessary recalculation occurs.
-	 */
-	private static readonly trimmedGraph = new GraphNodeSet<Compute, Dependency>();
-
-	/**
-	 * Register a dependency of this {@link Compute} object.
+	 * A stack of {@link Compute Computes} keeping track of any {@link Compute} objects that are
+	 * currently in the process of being recalculated.
 	 *
-	 * Note: this method requires the calling object to implement {@link Compute}.
+	 * When a {@link Compute} begins it's recalculation, it is pushed onto this stack with an empty
+	 * set. Then, when a {@link Dependency} is accessed, a reference to itself is added to the
+	 * {@link Dependency} set attached to the element at the top of the stack. Once the
+	 * {@link Compute} has finished it's recalculation, it saves the {@link Dependency} set as the
+	 * only dependencies for the {@link Compute}.
 	 *
-	 * @param this The {@link Compute} object with the dependency.
-	 * @param dependency The {@link Store} which {@link compute} is dependent on.
+	 * This method of dependency discovery relies on recalculation functions being deterministic,
+	 * i.e., they don't pull pre-cached data from outside the scope of the function itself. If this
+	 * occurs, some dependencies of a {@link Compute} may not be properly tracked, leading to
+	 * situations where a recalculation does not occur when it needs to. This can be mitigated by
+	 * always caching state data within the computation function, however there is no way to enforce
+	 * this in JavaScript.
+	 *
+	 * Another assumption of calculation functions is that they must be both synchronous and
+	 * blocking. If this assumption is not true for a calculation function, it may cause
+	 * re-calculations to finished in an order different than the reverse order in which they began.
+	 * In the event this occurs, a {@link DependencyError} will be thrown.
 	 */
-	protected registerDependency(this: Compute, dependency: Dependency) {
-		// add dependency
-		GraphItem.allComputes.add(this);
-		GraphItem.dependencyGraph.add(this, dependency);
+	private static readonly accessStack = new Array<[Compute, Set<Dependency>]>();
 
-		// recalculate
-		GraphItem.recalculateTrimmedGraph();
+	/**
+	 * Register that a {@link Dependency} has been accessed.
+	 *
+	 * If there is a {@link Compute} currently being calculated, {@link this} will be tracked as a
+	 * dependency of that {@link Compute}.
+	 *
+	 * @param this The dependency that was accessed.
+	 */
+	protected wasAccessed(this: Dependency) {
+		// inspect (not pop) top item references off the access stack
+		const topItem = GraphItem.accessStack.at(-1);
+		if (topItem === undefined) return;
+
+		// add dependency to the access stack
+		topItem[1].add(this);
 	}
 
 	/**
-	 * Recalculate all {@link Compute} values which depend on a {@link dependency}.
+	 * Notify the dependency graph that a {@link Compute} is beginning its calculation.
 	 *
-	 * Note: this method requires the calling object to extend {@link Store}.
+	 * It is imperative this method is called at the beginning of any computation as to properly
+	 * track its dependencies. Usually, such as in the case of {@link Computed} or {@link Effect},
+	 * this is done automatically, however any non-standard implementations must ensure this method
+	 * is called itself.
 	 *
-	 * @param this This item to recalculate the dependency of.
+	 * It is also imperative to call {@link finishCalculation} at the end of any calculation.
+	 *
+	 * @param this The {@link Compute} value which is beginning its calculation.
+	 */
+	protected beginCalculation(this: Compute) {
+		GraphItem.accessStack.push([this, new Set()]);
+	}
+
+	/**
+	 * Notify the dependency graph that a {@link Compute} has finished its calculation.
+	 *
+	 * It is imperative this method is called at the end of an computation as to properly stop
+	 * tracking its dependencies. Usually, such as in the case of {@link Computed} or
+	 * {@link Effect}, this is done automatically, however any non-standard implementations must
+	 * ensure this method is called itself.
+	 *
+	 * It is also imperative to call {@link beginCalculation} at the start of any calculation.
+	 *
+	 * @param this
+	 */
+	protected finishCalculation(this: Compute) {
+		// pop top item off the access stack
+		const dependencyAccesses = GraphItem.accessStack.pop();
+		if (dependencyAccesses === undefined)
+			throw DependencyError.untrackedComputationFinished(this);
+
+		// ensure the dependencies are for the correct computed value
+		const [compute, dependencies] = dependencyAccesses;
+		if (compute !== this) throw DependencyError.incorrectComputationFinished(this, compute);
+
+		// update dependencies for this compute
+		GraphItem.dependencyMap.set(compute, dependencies);
+	}
+
+	/**
+	 * Notify all the {@link Compute Computes} of a {@link Dependency} that a dependency has had its
+	 * value changed and a recalculation should commence.
+	 *
+	 * @param this The {@link Dependency} which has changed.
 	 */
 	protected notifyDependents(this: Dependency) {
-		const toNotify = GraphItem.trimmedGraph.getFirstsForSecond(this);
-		for (const compute of toNotify) compute.compute();
-	}
-
-	/**
-	 * Determine whether a {@link Store} has been registered as a {@link Compute}.
-	 *
-	 * While calling method does not require {@link this} to implement {@link Compute}, if it
-	 * doesn't, there is no chance it being found as a registered {@link Compute}. However, if it
-	 * is found, it's type with also be narrowed to include the fact it does implement
-	 * {@link Compute}.
-	 *
-	 * Note: this method requires the calling object to extend {@link Store}.
-	 *
-	 * @param this The store to check.
-	 * @returns Whether {@link store} is also a registered {@link Compute}.
-	 */
-	private isRegisteredCompute(this: Dependency): this is Compute {
-		return GraphItem.allComputes.has(this as unknown as Compute);
-	}
-
-	/**
-	 * Recalculate the {@link GraphItem.trimmedGraph} to take into consideration new dependency
-	 * relationships.
-	 */
-	private static recalculateTrimmedGraph() {
-		GraphItem.trimmedGraph.clear();
-
-		for (const compute of GraphItem.allComputes) {
-			// calculate direct and indirect dependencies
-			const { direct, indirect } = GraphItem.discoverAllDependencies(compute, compute);
-
-			// only keep direct dependencies that aren't also indirect dependencies
-			const trimmedDirect = direct.difference(indirect);
-			for (const dependency of trimmedDirect) GraphItem.trimmedGraph.add(compute, dependency);
+		for (const [compute, dependencies] of GraphItem.dependencyMap) {
+			if (dependencies.has(this)) compute.compute();
 		}
 	}
+}
+
+/**
+ * Errors relating to the automatic dependency management system.
+ */
+class DependencyError extends MessageBoxError {
+	/**
+	 * Error for when a {@link Compute} finishes its calculation while the access stack is empty.
+	 *
+	 * This error usually means a calculation did not call {@link GraphItem.beginCalculation} when
+	 * it should have.
+	 *
+	 * @param compute The {@link Compute} which just finished its calculation.
+	 * @returns The error.
+	 */
+	static untrackedComputationFinished(compute: Compute) {
+		return new DependencyError(
+			`Computation ${compute} finished, however no computations we registered as having been started.`
+		);
+	}
 
 	/**
-	 * Find all dependencies for a {@link Compute}.
+	 * Error for when the {@link Compute} that has just finished its calculation is not the same as
+	 * the {@link Compute} on the top of the stack.
 	 *
-	 * Dependencies can either be direct (in cases where the {@link Compute} directly specifies a
-	 * dependency) or indirect (in cases for dependencies of dependencies).
+	 * This error usually means calculations finished out of order due to either being asynchronous
+	 * or non-blocking, however could also be if {@link GraphItem.beginCalculation} or
+	 * {@link GraphItem.finishCalculation} are not called when they should be.
 	 *
-	 * @param compute The current {@link Compute} value to find all dependencies for.
-	 * @param rootCompute The root {@link Compute} value which was originally requested.
-	 * @param direct All currently discovered direct dependencies.
-	 * @param indirect All currently discovered indirect dependencies.
-	 * @returns All direct and indirect dependences of {@link rootCompute}.
+	 * @param compute The {@link Compute} which just finished its calculation.
+	 * @param expectedCompute The expected {@link Compute} value to have finished.
+	 * @returns The error.
 	 */
-	private static discoverAllDependencies(
-		currentCompute: Compute,
-		rootCompute: Compute,
-		direct?: Set<Dependency>,
-		indirect?: Set<Dependency>
-	) {
-		direct ??= new Set();
-		indirect ??= new Set();
-
-		// find all relevant dependencies
-		for (const [compute, dependency] of GraphItem.dependencyGraph) {
-			if (compute !== currentCompute) continue;
-
-			// record direct or indirect dependency, skipping it if it's already been registered
-			if (currentCompute === rootCompute) direct.add(dependency);
-			else if (!indirect.has(dependency)) indirect.add(dependency);
-			else continue;
-
-			// check for any nested dependencies
-			if (dependency.isRegisteredCompute())
-				GraphItem.discoverAllDependencies(dependency, rootCompute, direct, indirect);
-		}
-
-		return { direct, indirect };
+	static incorrectComputationFinished(compute: Compute, expectedCompute: Compute) {
+		return new DependencyError(
+			`Computations finished out of order: expected ${expectedCompute} to finish next, however ${compute} finished before.`
+		);
 	}
 }


### PR DESCRIPTION
## Overview

The dependency management system relies on each computed value separately specifying their dependencies in an array which is problematic for two reasons:

1. It is possible for implementers to miss/forget to add a dependency to the array even though they used it in the compute function, leading to calculations possibly not being performed when they should be.
2. Computed values sometimes will be re-calculated unnecessarily if a dependency that wasn't used in the previous calculation changes. For example, if `a = undefined` and `b = 3`, it doesn't matter if `b` changes if `a` being `undefined` causes the calculation function to return early and never get around to using `b`. So, no matter how many times `b` changes, the computed value should wait until `a` changes to perform any recalculations.

To solve this, dependency management has moved to a more modern and automatic implementation where, as a value recalculates, the dependencies it accesses are tracked, with only the dependencies accessed being added to the dependency graph. Then, when the value is computed again in the future, dependencies are once again tracked and, if new state values are accessed or others aren't, the dependency graph is updated to reflect these changes.

## Notes

* A calculation of a computed value must occur when the value is initialised otherwise the dependency management system will not know under what circumstances the value should be recalculated.
* Compute functions are required to be both synchronous and blocking. If not, the dependency management system will not know which calculations are being completed at what times and it could lead to incorrect dependencies being added.
* The dependency graph is no longer trimmed. Previously, trimming the graph was something that was done upon initialisation of a computed value, however since the dependencies of computed values now change dynamically depending on the last run of a calculation, trimming the graph would have to occur after each time a computed value changes. It it unclear whether this is worth the performance hit to occasionally trim dependencies (occasional because dependencies are managed automatically so there is less chance of double-up from user error).