### PR TITLE
Added missing `yarn install` command to GitHub Action

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,6 +19,7 @@ jobs:
               run: |
                   npm install -g yarn
                   yarn install
+                  yarn --cwd cli install
                   yarn merge build
             - name: Deploy
               uses: s0/git-publish-subdir-action@develop


### PR DESCRIPTION
## Overview

The new Merge CLI did not have its dependencies installed before running on GitHub Actions. This has been added.